### PR TITLE
Was dropping the first entry of the consensus file. Fixed.

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -659,25 +659,8 @@ func parseConsensusFile(fileName string, lazy bool) (*Consensus, error) {
 // ParseRawConsensus parses a raw consensus (in string format) and
 // returns a network consensus if parsing was successful.
 func ParseRawConsensus(rawConsensus string, lazy bool) (*Consensus, error) {
-	// First line of the string is the annotation
-	consensus := strings.SplitN(rawConsensus, "\n", 2)
-
-	// CheckAnnotation
-	parsedAnnon, err := parseAnnotation(consensus[0])
-	if err != nil {
-		return nil, err
-	}
-
-	// Check we support the observed annotation.
-	for annotation := range consensusAnnotations {
-		if annotation.Equals(parsedAnnon) {
-			r := strings.NewReader(consensus[1])
-
-			return parseConsensusUnchecked(r, lazy)
-		}
-	}
-
-	return nil, fmt.Errorf("Unexpected file annotation: %s", parsedAnnon)
+	r := strings.NewReader(rawConsensus)
+	return parseConsensus(r, lazy)
 }
 
 // LazilyParseConsensusFile parses the given file and returns a network


### PR DESCRIPTION
parseConsensus already does readAndCheckAnnotation; so instead of doing string manipulation lets just make it simple.

This also fixes an issue I was seeing where the first entry of the consensus file was being dropped.